### PR TITLE
Unpin noalgotube post from featured blogs

### DIFF
--- a/src/data/blog/noalgotube-algorithm-free-youtube-rss-reader.md
+++ b/src/data/blog/noalgotube-algorithm-free-youtube-rss-reader.md
@@ -5,7 +5,7 @@ pubDatetime: 2026-04-20T03:00:00.000Z
 description: "A personal content aggregator for YouTube and RSS feeds with no recommendations, no tracking, no algorithm. Just the channels you follow."
 tags: ["open-source", "self-hosting", "youtube", "rss", "homelab", "fastapi"]
 ogImage: "/optimized/assets/images/noalgotube-algorithm-free-youtube-rss-reader/cover.webp"
-featured: true
+featured: false
 draft: false
 ---
 


### PR DESCRIPTION
Sets `featured: false` on the noalgotube blog post to remove it from the pinned/featured section of the homepage.